### PR TITLE
Fix to ignore zero length files

### DIFF
--- a/Community.StyleCop.Rules/LayoutRules.cs
+++ b/Community.StyleCop.Rules/LayoutRules.cs
@@ -77,6 +77,12 @@ namespace Community.StyleCop.CSharp
                 (this.IncludeGenerated ||
                 !csDocument.RootElement.Generated))
             {
+                if (csDocument.Tokens != null && csDocument.Tokens.Count == 0)
+                {
+                    // early return if document is empty.
+                    return;
+                }
+
                 // check start of document
                 this.CheckIfFileStartsWithWhitespace(
                     csDocument.RootElement,


### PR DESCRIPTION
(Sometimes few msbuild tasks are generating empty files.
StyleCop Task fails with null ref exception without this fix.)
